### PR TITLE
Fix unremoved resize event listener

### DIFF
--- a/src/Section.js
+++ b/src/Section.js
@@ -7,6 +7,8 @@ class Section extends React.Component {
         this.state = {
             windowHeight: 0
         };
+
+	this.handleResize = this.handleResize.bind(this);
     }
 
     handleResize() {
@@ -17,11 +19,11 @@ class Section extends React.Component {
 
     componentDidMount() {
         this.handleResize();
-        window.addEventListener('resize', () => this.handleResize());
+        window.addEventListener('resize', this.handleResize);
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', () => this.handleResize());
+        window.removeEventListener('resize', this.handleResize);
     }
 
     render() {


### PR DESCRIPTION
Event listener is not removed in componentWillUnmount sinse the result of `() => this.handleResize() ==  () => this.handleResize()` is false. It cause warning in debug mode.